### PR TITLE
Formats 4.04 Do Now program output better

### DIFF
--- a/units/4_unit/04_lesson/do_now.md
+++ b/units/4_unit/04_lesson/do_now.md
@@ -10,8 +10,8 @@
     ['apt2a', 'apt2b', 'apt2c'],
     ['apt3a', 'apt3b', 'apt3c']
     ]
-    print("first floor" + str(my_building[0]))
-    print("first floor, 3rd apartment" + str(my_building[0][2]))
+    print("first floor: " + str(my_building[0]))
+    print("first floor, 3rd apartment: " + str(my_building[0][2]))
     ```
 
     Write down what was printed. How you would access the 2nd apartment of the 3rd floor (`apt3b`)?


### PR DESCRIPTION
Adds a colon and a space to yield

first floor: ['apt1a', 'apt1b', 'apt1c']
first floor, 3rd apartment: apt1c

rather than the incumbent

first floor['apt1a', 'apt1b', 'apt1c']
first floor, 3rd apartmentapt1c