### PR TITLE
Renames user commands in lab 4.04

### DIFF
--- a/units/4_unit/04_lesson/lab.md
+++ b/units/4_unit/04_lesson/lab.md
@@ -4,7 +4,7 @@
 The goal of this lab is to practice using and accessing items from lists of lists. 
 
 You have a few errands to run and have created a few shopping list to help you remember what to buy. You stored your notes in a nested list, `shopping_cart`. 
-This program will allow the user to ask for a specific item by it's index or update what items are in the cart. The user can request you `print all` the items in a specific shopping list.
+This program will allow the user to ask for a specific item by it's index or update what items are in the cart. The user can request to `view list` to see the items in a specific shopping list.
 
 ###Schedule 
 
@@ -18,11 +18,11 @@ shopping_cart = [
 
 ### User Inputs
 * `update`
-	* The program will ask which shopping list the user wants to update, which position it should update, and the new value to update.
-* `print` 
-	*  The program will ask which shopping list the user wants to print from and afterwards will request which position it should print.
-* `print all`
-	* The program will ask which shopping list the user wants to print and will print all of the items associated with that shopping list. 	
+	* The program asks which shopping list the user wants to update, which position it should update, and the new value to update.
+* `view item` 
+	*  The program asks which shopping list the item is on and which position it occupies, then prints the items name.
+* `view list`
+	* The program asks which shopping list the user wants and prints all of the items associated with that shopping list. 	
 	
 ###Functions
 * `update_list`
@@ -37,8 +37,8 @@ shopping_cart = [
 ### Example
 
 ```
->>>What would you like to do? print all
-Which shopping list would you like to print? 1
+>>>What would you like to do? view list
+Which shopping list would you like to see? 1
 tooth paste, q-tips, gum
 ```
 


### PR DESCRIPTION
Changes the user commands from "print" and "print all" to "view item'" and "view list".

A few motivations for this: a natural extension for students to write is a mechanism to print the whole cart. Since that's more than printing a list, it's odd for the current "print all" not to print the whole cart. So renaming to "print item" and "print list" would make space for "print all" or "print cart".

However, think "view" is a more natural word for users to have in their command, since it is agnostic to the way the view happens (command-line, phone app, etc.) the user command "print" is better for putting things onto paper. Making the user commands "view *" also makes more clear the distinction between the user command "view item", "view list" and the student-defined functions print_list(), print_item().

For a reference implementation of the lab using these new terms, see https://repl.it/@davidrhmiller/TEALS2018-Lab-404-Shopping-List