### PR TITLE
Lab 4.04: Fixes _ vs - bug in count_q_tips spec

### DIFF
--- a/units/4_unit/04_lesson/lab.md
+++ b/units/4_unit/04_lesson/lab.md
@@ -47,7 +47,7 @@ tooth paste, q-tips, gum
 In this part of the lab you will go through your shopping list program and perform a few different calculations. 
 
 1. Create a function, `all_in_one`, that will put all the shopping lists into a single list using a for loop. 
-2. Create a function, `count_q_tips`, which will go through all items of the list and keep a count of how many times `'q_tips'` occurs. 
+2. Create a function, `count_q_tips`, which will go through all items of the list and keep a count of how many times `'q-tips'` occurs. 
 3. In order to make the shopping lists more calcium rich, write a function, `drink_more_milk`, that adds `'milk'` to each of the lists (unless it's already there). 
 4. You can't have milk without cookies. Write a function `if_you_give_a_moose_a_cookie`, that will go through every element of schedule and update `'milk'` to be `'milk and cookies'`.
 


### PR DESCRIPTION
The function name is count_q_tips(), but the thing in the list is 'q-tips' with a hyphen, not an underscore. So the description of count_q_tips() should as for the count of occurrences of 'q-tips', not of 'q_tips'.