### PR TITLE
Updates example in Lesson 6.3 do now

### DIFF
--- a/units/6_unit/03_lesson/do_now.md
+++ b/units/6_unit/03_lesson/do_now.md
@@ -3,12 +3,15 @@
 1. Type and run the following code in the interpreter: 
 
     ```python
-list_dictionaries = {
-	'cat': [1, 3, 4],
-	'is': [1, 2, 3, 4]
+weekend_dates = {
+  'April 2018': [7, 8, 14, 15, 21, 22, 28, 29],
+  'May 2018': [5, 6, 12, 13, 19, 20, 26, 27]
 }
-print(list_dictionaries['cat'])
-    ```
-Write down what type `list_dictionaries` is, what type the keys are, and what type the values are. <br><br><br>
 
-2. Write code so that the value of 'is' becomes `[1, 2, 3, 4, 5]`
+print(weekend_dates['April 2018'])
+    ```
+Write down what type `weekend_dates` is, what type the keys are, and what type the values are. <br><br><br>
+
+2. The Memorial Day holiday is observed on May 28, which makes it a
+   long weekend. Write code so that the value of 'May 2018' becomes
+   `[5, 6, 12, 13, 19, 20, 26, 27, 28]`

--- a/units/6_unit/03_lesson/do_now.md
+++ b/units/6_unit/03_lesson/do_now.md
@@ -16,6 +16,7 @@ what type the values are.
 <br><br><br>
 
 2. The 2018 Memorial Day holiday is observed on Monday, May 28, which makes it a
-   long-weekend day. Write a new line of code that adds May 28th to the
-   `May 2018` list, so that its value becomes
+   long-weekend day. Write a new line of code that adds May 28th to
+   the list associated with
+   `'May 2018'`, so that its value becomes
    `[5, 6, 12, 13, 19, 20, 26, 27, 28]`.

--- a/units/6_unit/03_lesson/do_now.md
+++ b/units/6_unit/03_lesson/do_now.md
@@ -15,6 +15,7 @@ Write down what type `weekend_dates` is, what type the keys are, and
 what type the values are.
 <br><br><br>
 
-2. The Memorial Day holiday is observed on May 28, which makes it a
-   long weekend. Write code so that the value of 'May 2018' becomes
-   `[5, 6, 12, 13, 19, 20, 26, 27, 28]`
+2. The 2018 Memorial Day holiday is observed on Monday, May 28, which makes it a
+   long-weekend day. Write a new line of code that adds May 28th to the
+   `May 2018` list, so that its value becomes
+   `[5, 6, 12, 13, 19, 20, 26, 27, 28]`.

--- a/units/6_unit/03_lesson/do_now.md
+++ b/units/6_unit/03_lesson/do_now.md
@@ -2,15 +2,18 @@
 
 1. Type and run the following code in the interpreter: 
 
-    ```python
+```python
 weekend_dates = {
   'April 2018': [7, 8, 14, 15, 21, 22, 28, 29],
   'May 2018': [5, 6, 12, 13, 19, 20, 26, 27]
 }
 
 print(weekend_dates['April 2018'])
-    ```
-Write down what type `weekend_dates` is, what type the keys are, and what type the values are. <br><br><br>
+```
+
+Write down what type `weekend_dates` is, what type the keys are, and
+what type the values are.
+<br><br><br>
 
 2. The Memorial Day holiday is observed on May 28, which makes it a
    long weekend. Write code so that the value of 'May 2018' becomes

--- a/units/6_unit/03_lesson/lesson.md
+++ b/units/6_unit/03_lesson/lesson.md
@@ -27,11 +27,12 @@ Students will be able to...
     * Students will explore how to use dictionaries containing lists, as well as how to add values to those lists.
 2. **Lesson**
 	* Discuss part 1 of the Do Now.
-		* Go over the type of `list_dictionaries`. 
-		    * It is still a dictionary type which goes from string (key) to list (value). Dictionaries can also go from numbers to lists, or numbers to strings, or any other combination. 
+		* Go over the type of `weekend_dates`. 
+		    * It is still a dictionary type. In this case the
+              dictionary goes from string (key) to list (value). Dictionaries can also go from numbers to lists, or numbers to strings, or any other combination. 
 	* Discuss part 2 of the Do Now. 
 		* Review how you update a value within a dictionary, as well as how to append and remove items from lists. 
-		* Have students continue practicing adding and removing values from `list_dictionaries`.  
+		* Have students continue practicing adding and removing values from `weekend_dates`.  
 3. **Lab**	
 	* Students will create a dictionary representing a weekly to-do list. The user can add items to the to-do list or have the program print what items must be done on a certain day.
 4. **Debrief**


### PR DESCRIPTION
The Lesson 6.3 Do Now example dictionary is not very well motivated, and poorly named. This change replaces it with a meaningful example, a dictionary containing lists of weekend dates for the months April 2018 and May 2018.