### PR TITLE
Sets PDF output option for paper size to letter, not the default a4.

### DIFF
--- a/book.json
+++ b/book.json
@@ -8,5 +8,8 @@
     "structure": {
         "readme":  "README.md",
         "summary": "SUMMARY.md"
+    },
+    "pdf": {
+	"paperSize": "letter"
     }
 }


### PR DESCRIPTION
Most users of this book are in the US, where a4 is a non-standard size. See https://toolchain.gitbook.com/config.html for details.