### PR TITLE
Tweak GitBook version in book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "gitbook":     ">=3.0.0-pre.0",
+    "gitbook":     ">= 3.0.0",
     "title":       "2nd Semester Intro to Computer Science",
     "description": "A 2nd semester follow-up to the TEALS intro CS course",
     "author":      "TEALSK12 - https://www.tealsk12.org",


### PR DESCRIPTION
In most example, there's a space after the relational operator in the
semver field, so I'm adding one here. Also changing to ">= 3.0.0" from
">=3.0.0-beta.0".