### PR TITLE
Correct EarSketch documentation numbers

### DIFF
--- a/units/5_unit/04_lesson/do_now.md
+++ b/units/5_unit/04_lesson/do_now.md
@@ -2,9 +2,9 @@
 
 1. Begin reading the following lessons of the EarSketch documentation in [Unit 2](http://earsketch.gatech.edu/category/unit-2).
 
-* 2.10.1 [Sections and Form](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-0)
-* 2.10.2 [A-B-A form](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-1)
-* 2.10.3 [Custom Functions](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-2)
+* 2.9.1 [Sections and Form](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-0)
+* 2.9.2 [A-B-A form](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-1)
+* 2.9.3 [Custom Functions](https://earsketch.gatech.edu/earsketch2/?curriculum=2-2-2)
 
 2. Answer the following questions, based on the reading:
     * Why might it be useful to group sections of music into functions?<br><br><br>


### PR DESCRIPTION
EarSketch documentation has moved these sections slightly. Looks like the links no longer open the documentation section either.