### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For those knowledgeable with Python 2, the following is a list of differences fr
 | Printing to console | print 3.14 | print (3.14) |
 | User input | raw_input()/input() | input () |
 | Integer arithmetic | 3/2 evaluates to 1 | 3/2 evaluates to 1.5 |
-| Not equal to | <> | != |
 
 ### IDE Selection
 


### PR DESCRIPTION
Despite `<>` being valid in Python 2 and not valid in Python 3, it is _extremely_ uncommon to ever see this comparison operator, because Python 2 also has `!=`. I personally feel like there are many more relevant differences between 2 and 3 that should be discussed before `<>`, like class declarations.

Of course, this is only a suggestion.