### PR TITLE
Fix broken link to example.py in unit 7.04

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 
 -----------------
 
+### 3/26/2023
+
+* 7.04 - Fixed broken example code link for lab (similar to #400)
+
+-----------------
+
 ### 5/16/2022
 
 * 7.05 - Fixed broken sample code link for project (Issues #380 and #398)

--- a/docs/changelog.md.html
+++ b/docs/changelog.md.html
@@ -13,6 +13,12 @@
 
 -----------------
 
+### 3/26/2023
+
+* 7.04 - Fixed broken example code link for lab (similar to #400)
+
+-----------------
+
 ### 5/16/2022
 
 * 7.05 - Fixed broken sample code link for project (Issues #380 and #398)

--- a/docs/units/7_unit/04_lesson/lab.md.html
+++ b/docs/units/7_unit/04_lesson/lab.md.html
@@ -11,7 +11,7 @@
 
 ## Overview
 
-Given the following [Sample Code], practice using inheritance to create specific child classes for different types of `Pokemon`.
+Given the following [Sample Code](https://github.com/TEALSK12/2nd-semester-introduction-to-computer-science/blob/master/units/7_unit/04_lesson/example.py), practice using inheritance to create specific child classes for different types of `Pokemon`.
 
 ### Create the three child classes below
 
@@ -42,7 +42,5 @@ my_pet = Pet()
 isinstance(my_pet, Pet) # returns true
 isinstance(my_pet, Dog) # returns false
 ```
-
-[Sample Code]: https://teals-introcs.gitbooks.io/2nd-semester-introduction-to-computer-science-pri/content/units/7_unit/04_lesson/example.py
 
 <!-- Markdeep: --><style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script><script>window.alreadyProcessedMarkdeep||(document.body.style.visibility="visible")</script>

--- a/units/7_unit/04_lesson/lab.md
+++ b/units/7_unit/04_lesson/lab.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Given the following [Sample Code], practice using inheritance to create specific child classes for different types of `Pokemon`.
+Given the following [Sample Code](https://github.com/TEALSK12/2nd-semester-introduction-to-computer-science/blob/master/units/7_unit/04_lesson/example.py), practice using inheritance to create specific child classes for different types of `Pokemon`.
 
 ### Create the three child classes below
 
@@ -33,5 +33,3 @@ my_pet = Pet()
 isinstance(my_pet, Pet) # returns true
 isinstance(my_pet, Dog) # returns false
 ```
-
-[Sample Code]: https://teals-introcs.gitbooks.io/2nd-semester-introduction-to-computer-science-pri/content/units/7_unit/04_lesson/example.py


### PR DESCRIPTION
This is fixing a similar issue to #398. I tried to follow what #400 did to resolve that issue.

I can't find any other references to `teals-introcs.gitbooks.io` in the codebase so hopefully this is the last of it.